### PR TITLE
Force LF as newline

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,13 +9,13 @@ repos:
   - id: requirements-txt-fixer
 
 - repo: https://github.com/psf/black
-  rev: 22.8.0
+  rev: 24.3.0
   hooks:
   - id: black
     args:
       - -l 88
 
 - repo: https://gitlab.com/pycqa/flake8
-  rev: '5.0.4'
+  rev: '7.0.0'
   hooks:
   - id: flake8

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,13 @@
 Changelog
 =========
 
+1.10.1
+------
+- Force LF as newline characted on all OS
+- Update pre-commit-config dependencies¨
+
 1.10.0
------
+------
 - Add support for ``itx`` and ``self.itx`` format
 
 1.9.0

--- a/popie/popiefile.py
+++ b/popie/popiefile.py
@@ -99,7 +99,7 @@ class PoPieFile:
 
     def save(self):
         """Dump the content into the file."""
-        with open(self.filename, "w", encoding="utf-8") as pofile:
+        with open(self.filename, "w", encoding="utf-8", newline="\n") as pofile:
             string_count: int = len(self.translations)
             for i, (msgid, msgstr) in enumerate(self.translations.items()):
                 pofile.write(f"msgid {msgid}\n")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = strawberry-tools
-version = 1.10.0
+version = 1.10.1
 
 url = https://github.com/strawberry-py/strawberry-tools
 description = Tools for the strawberry.py bot framework
@@ -11,6 +11,7 @@ classifiers =
 	Programming Language :: Python :: 3.8
 	Programming Language :: Python :: 3.9
 	Programming Language :: Python :: 3.10
+	Programming Language :: Python :: 3.11
 
 [options]
 package_dir =


### PR DESCRIPTION
Ther ewas one multi-platform problem. When you open a file without specifying new-line type, it will default to the system one. Which means on Windos CRLF and on Linux / Mac LF. This also means that there would be problem with pre-commit hooks, checks and more other things as the new-line character would make difference with the files and the differ will complain.

This can be easily fixed by opening the file with parameter newline set to `\n` and therefor forcing it to use LF only.

I've also updated pre-commit tools versions and bumped version to 1.10.1 and declared Python 11 support.